### PR TITLE
load_obj: pathing for sonvalidxml and schema are now os agnostic, i.e…

### DIFF
--- a/src/Main.py
+++ b/src/Main.py
@@ -113,8 +113,8 @@ class Accert:
         """    
 
         import subprocess
-        sonvalidxml = accert_path + "/bin/sonvalidxml"
-        schema = accert_path + "/src/etc/accert.sch"
+        sonvalidxml = os.path.join(accert_path, "bin", "sonvalidxml")
+        schema = os.path.join(accert_path, "src", "etc", "accert.sch")
         cmd = ' '.join([sonvalidxml, schema, input_path])
         xmlresult = subprocess.check_output(cmd, shell=True)
         ### obtain pieces of input by name for convenience


### PR DESCRIPTION
…. windows compatible

--------
Merge Request Description
--------
**What issue does this change request address?**
This change request resolves pathing issues encountered with Windows users to sonvalidxml and accert.sch.

**What are the changes due to this change request?**
This changes line 116 and 117 in Main.py to utilizes os library for pathing, when previously pathing was hardcoded as a string. This resolves pathing issue that was encountered with Windows machine.

----------------
For Change Request Review
----------------
- [ ] 1. Is the merge request reference an issue?  If the issue is closed, the issue close checklist shall be done.
          This does not reference an issue and was found while attempting to run example cases.
- [ ] 2. Is the merge request reference a task?  If the task is fulfilled, the task close checklist shall be done.
- [ ] 3. If any changes to the database, there must be an accompanying change to the all the linked tables.
